### PR TITLE
Fixing techdocs

### DIFF
--- a/ai-assets-techdocs/mkdocs.yml
+++ b/ai-assets-techdocs/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: ibm-granite-8b-code-instruct
 site_description: IBM Granite 8B Code Instruct
 # site_author: user:ben.wilcock
+docs_dir: models
 nav:
   - "IBM Granite 8B Code Instruct™": index.md
   


### PR DESCRIPTION
* Changed the `mkdocs.yaml` to `mkdocs.yml`, techdocs-cli expects `.yml` by default. I don't know if it's expected or a bug. IMO, it should honor both the file extensions.

* Techdocs cli (mkdocs) expects `docs_dir` to be `docs` dir by default if it's not defined. Otherwise, it will use the `docs_dir` value defined. In this case, I added `models` as `docs_dir` value in `mkdocs.yml`